### PR TITLE
Remove unused variable

### DIFF
--- a/conf/eth/scripts/build-eth-conf.sh
+++ b/conf/eth/scripts/build-eth-conf.sh
@@ -65,7 +65,6 @@ do
     # use a Docker container to run the geth command that creates accounts. This
 	# saves us the trouble of installing geth locally
     docker run --rm \
-		-u `id -u $USER` \
 		-v $dest:/datadir \
 		-v $PASS:/pwd.txt \
 		ethereum/client-go -verbosity=1 --datadir=/datadir --password=/pwd.txt account new  | \

--- a/makefile
+++ b/makefile
@@ -1,6 +1,5 @@
 ENV = local
 VERSION = 0.1.1 # evm-lite Docker Image
-USER = 1000 # user that run evml inside the docker containers. (try 501 in MacOS)
 CONSENSUS = babble # babble or solo
 NODES = 1
 IPBASE = node
@@ -13,7 +12,7 @@ conf:
 	$(MAKE) -C conf/$(CONSENSUS) conf NODES=$(NODES) IPBASE=$(IPBASE) IPADD=$(IPADD)
 
 start:
-	$(MAKE) -C terraform/$(ENV) apply NODES=$(NODES) CONSENSUS=$(CONSENSUS) VERSION=$(VERSION) USER=$(USER)
+	$(MAKE) -C terraform/$(ENV) apply NODES=$(NODES) CONSENSUS=$(CONSENSUS) VERSION=$(VERSION)
 
 stop:
 	$(MAKE) -C terraform/$(ENV) destroy

--- a/terraform/local/makefile
+++ b/terraform/local/makefile
@@ -1,4 +1,3 @@
-USER = 1000
 NODES = 1
 CONSENSUS = solo
 VERSION = latest
@@ -7,7 +6,6 @@ CONF = $(CURDIR)/../../conf/$(CONSENSUS)/conf
 apply:
 	rm -f ips.dat && \
 	terraform apply -auto-approve \
-		-var user=$(USER) \
 		-var command=$(CONSENSUS) \
 		-var nodes=$(NODES) \
 		-var version=$(VERSION) \


### PR DESCRIPTION
Since the 'user' variable is used for specifying the user and the
EVM-Lite directory in docker container, it is unnecessary to let user
change this variable from the shell scripts.

To avoid misusing this variable, remove it from the shell scripts.